### PR TITLE
Add ImmutableConfig

### DIFF
--- a/aconfig/__init__.py
+++ b/aconfig/__init__.py
@@ -8,4 +8,4 @@
 '''Enable calls to desired components of package.
 '''
 
-from .aconfig import AttributeAccessDict, Config
+from .aconfig import AttributeAccessDict, Config, ImmutableAttributeAccessDict, ImmutableConfig

--- a/aconfig/aconfig.py
+++ b/aconfig/aconfig.py
@@ -48,6 +48,9 @@ class AttributeAccessDict(dict):
 
     @classmethod
     def _make_attribute_access_dict(cls, value):
+        """Recursively walk down any `dict`s or `list`s and build attribute access dicts
+        🌶️🌶️🌶️: This is a classmethod so that inheritance is respected.
+        """
         if isinstance(value, cls):
             return value
         elif isinstance(value, dict):
@@ -87,8 +90,15 @@ class AttributeAccessDict(dict):
 
 
 class ImmutableAttributeAccessDict(AttributeAccessDict):
+    """This class subclasses AttributeAccessDict and removes the setters,
+    to allow the creation of immutable dicts.
+
+    Using inheritance this way allows the dicts to be recursively created via
+    AttributeAccessDict, while maintaining nested immutability.
+    """
 
     def __init__(self, input_map, *_):
+        """See :func:`~aconfig.aconfig.AttributeAccessDict.__init__`"""
         assert isinstance(input_map, dict), \
             '`input_map` argument should be of type dict, but found type: <{0}>'.format(
                 type(input_map))
@@ -100,10 +110,10 @@ class ImmutableAttributeAccessDict(AttributeAccessDict):
         super().__init__(input_map)
 
     def __setitem__(self, key, value):
-        raise TypeError("Nope")
+        raise TypeError("ImmutableAttributeAccessDict does not support item assignment")
 
     def __setattr__(self, key, value):
-        raise TypeError("Nope")
+        raise TypeError("ImmutableAttributeAccessDict does not support item assignment")
 
 
 class Config(AttributeAccessDict):
@@ -315,7 +325,9 @@ class Config(AttributeAccessDict):
 
 
 class ImmutableConfig(ImmutableAttributeAccessDict, Config):
+    """This class is the Immutable version of Config"""
     def __init__(self, config, override_env_vars=True):
+        """See :func:`~aconfig.aconfig.Config.__init__`"""
         assert isinstance(config, dict)
         super().__init__(config, override_env_vars)
 

--- a/test/test_attribute_access_dict.py
+++ b/test/test_attribute_access_dict.py
@@ -215,18 +215,18 @@ class TestAttributeAccessDict(unittest.TestCase):
         self.assertNotIn('update', aad)
 
     def test_immutable_flat_access_dict(self):
-        '''Test that frozen flat access dict cannot be changed
+        '''Test that immutable flat dict cannot be changed
         '''
-        flat_dict = aconfig.AttributeAccessDict(fixtures.GOOD_FLAT_DICT, frozen=True)
+        flat_dict = aconfig.ImmutableAttributeAccessDict(fixtures.GOOD_FLAT_DICT)
         self.assertIsInstance(flat_dict, aconfig.AttributeAccessDict)
 
         with self.assertRaises(TypeError):
             flat_dict['str_key'] = 'new_key'
     
     def test_immutable_nested_access_dict(self):
-        '''Test that frozen nested access dict cannot be changed
+        '''Test that immutable nested dict cannot be changed
         '''
-        flat_dict = aconfig.AttributeAccessDict(fixtures.GOOD_NESTED_DICT, frozen=True)
+        flat_dict = aconfig.ImmutableAttributeAccessDict(fixtures.GOOD_NESTED_DICT)
         self.assertIsInstance(flat_dict, aconfig.AttributeAccessDict)
 
         with self.assertRaises(TypeError):

--- a/test/test_attribute_access_dict.py
+++ b/test/test_attribute_access_dict.py
@@ -213,3 +213,21 @@ class TestAttributeAccessDict(unittest.TestCase):
 
         self.assertNotEqual(aad.update, None)
         self.assertNotIn('update', aad)
+
+    def test_immutable_flat_access_dict(self):
+        '''Test that frozen flat access dict cannot be changed
+        '''
+        flat_dict = aconfig.AttributeAccessDict(fixtures.GOOD_FLAT_DICT, frozen=True)
+        self.assertIsInstance(flat_dict, aconfig.AttributeAccessDict)
+
+        with self.assertRaises(TypeError):
+            flat_dict['str_key'] = 'new_key'
+    
+    def test_immutable_nested_access_dict(self):
+        '''Test that frozen nested access dict cannot be changed
+        '''
+        flat_dict = aconfig.AttributeAccessDict(fixtures.GOOD_NESTED_DICT, frozen=True)
+        self.assertIsInstance(flat_dict, aconfig.AttributeAccessDict)
+
+        with self.assertRaises(TypeError):
+            flat_dict['key2']['key4'] = 'new_key'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -231,6 +231,6 @@ class TestConfig(unittest.TestCase):
         assert yaml_dump == yaml_safe_dump
 
         # Load both ways
-        yaml_loaded = yaml.load(yaml_dump)
+        yaml_loaded = yaml.full_load(yaml_dump)
         yaml_safe_loaded = yaml.safe_load(yaml_dump)
         assert yaml_loaded == yaml_safe_loaded

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -221,6 +221,12 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(cfg.a.b[0].c, 1)
         self.assertEqual(cfg_copy.a.b[0].c, 2)
 
+        immutable_cfg = aconfig.ImmutableConfig(cfg)
+        immutable_cfg_copy = copy.deepcopy(immutable_cfg)
+        self.assertIsInstance(immutable_cfg_copy, aconfig.ImmutableConfig)
+        self.assertEqual(immutable_cfg_copy, immutable_cfg)
+        self.assertIsNot(immutable_cfg_copy, immutable_cfg)
+
     def test_yaml_dump(self):
         '''Test yaml.dump(config) works'''
         loaded_yaml = aconfig.Config.from_yaml(fixtures.GOOD_CONFIG_LOCATION)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -234,3 +234,30 @@ class TestConfig(unittest.TestCase):
         yaml_loaded = yaml.full_load(yaml_dump)
         yaml_safe_loaded = yaml.safe_load(yaml_dump)
         assert yaml_loaded == yaml_safe_loaded
+
+    def test_immutable_config(self):
+        cfg = aconfig.ImmutableConfig({'a': {'b': [{'c': 1}]}})
+        self.assertEqual(cfg.a.b[0].c, 1)
+
+        with self.assertRaises(TypeError):
+            cfg.a.b[0].c = 2
+        with self.assertRaises(TypeError):
+            cfg.a.b = [1, 2, 3]
+        with self.assertRaises(TypeError):
+            cfg.a = 1
+
+    def test_immutable_config_with_env_overrides(self):
+        # set an environment
+        os.environ['KEY1'] = '12345678'
+        cfg = aconfig.ImmutableConfig({"key1": 1, "key2": 2}, override_env_vars=True)
+
+        assert cfg.key2 == 2
+        assert cfg.key1 == 12345678
+        with self.assertRaises(TypeError):
+            cfg.key1 = 1
+
+    def test_immutable_config_from_mutable_config(self):
+        cfg = aconfig.Config({'a': {'b': [{'c': 1}]}})
+        immutable_config = aconfig.ImmutableConfig(cfg)
+
+        assert cfg == immutable_config


### PR DESCRIPTION
Closes #3 

This PR adds an `ImmutableConfig` which looks and feels like a `Config`, but has fully nested immutability.

We wanted to try using a `mappingproxy` but unfortunately those are final and can't be extended. See related: https://stackoverflow.com/questions/66037137/immutable-frozen-dictionary-subclass-with-fixed-key-value-types

Instead we subclassed `AttributeAccessDict` and removed the setters. Along with updating some static type references in `AttributeAccessDict` to `cls` references to respect inheritance, this allows the recursive nesting to still happen but results in immutable dicts.