### PR TITLE
:technologist: Add better assertion messages

### DIFF
--- a/aconfig/aconfig.py
+++ b/aconfig/aconfig.py
@@ -213,10 +213,10 @@ class Config(AttributeAccessDict):
         config_location = os.path.normpath(config_location)
 
         assert (config_location.endswith('.yml') or config_location.endswith('.yaml')), \
-            'Must send in a .yaml or .yaml file'
+            'Must send in a .yaml or .yaml file, you sent in: <{0}>'.format(config_location)
 
         assert os.path.exists(config_location), \
-            'config_location does not exist or cannot be found!'
+            'config_location <{0}> does not exist or cannot be found!'.format(config_location)
 
         # finally found it's valid
         return config_location

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -48,6 +48,7 @@ class TestConfig(unittest.TestCase):
             bad_config2 = aconfig.Config._verify_config_location(fixtures.BAD_CONFIG_LOCATION)
         raised_exception2 = ex2.exception
         self.assertIsInstance(raised_exception2, AssertionError)
+        self.assertIn(fixtures.BAD_CONFIG_LOCATION, str(ex2.exception))
         # make sure bad_config2 was NOT initialized
         self.assertEqual(getattr(locals(), 'bad_config2', None), None)
 
@@ -56,6 +57,7 @@ class TestConfig(unittest.TestCase):
             bad_config3 = aconfig.Config._verify_config_location(fixtures.NOT_YAML_CONFIG_LOCATION)
         raised_exception3 = ex3.exception
         self.assertIsInstance(raised_exception3, AssertionError)
+        self.assertIn(fixtures.NOT_YAML_CONFIG_LOCATION, str(ex3.exception))
         # make sure bad_config3 was NOT initialized
         self.assertEqual(getattr(locals(), 'bad_config3', None), None)
 


### PR DESCRIPTION
This PR adds some better assertion messages when configs can't be loaded.

This is required to allow devs to figure out what's wrong in the case of loading multiple config files. Without it, all you get is "config_location does not exist..." and it's up to you to open a debugger or examine your own stack trace to figure out which config file path is bad.